### PR TITLE
Added support for Laravel 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "illuminate/contracts": "^6.0",
-        "illuminate/support": "^6.0",
-        "illuminate/database": "^6.0"
+        "php": "^7.2.5",
+        "illuminate/contracts": "^7.0",
+        "illuminate/support": "^7.0",
+        "illuminate/database": "^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0",
+        "orchestra/testbench": "^5.0",
         "phpunit/phpunit": "~7.0|^8.0"
     },
     "autoload": {


### PR DESCRIPTION
I am not too familiar with Travis but tried to update the config file as needed.
I left PHP Version 7.2 in there whilst the minimum required version for Laravel 7 is now 7.2.5.
Not sure if I had to update that to 7.2.5 aswel.